### PR TITLE
Changes to adapt to the new automatic configuration of the Keycloak in dashboard.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,7 @@ COPY scripts/handler-new-pulsefile.py /home/imas/opt/imas-inotify/handler-new-pu
 COPY --chown=imas:imas external/demonstrator-dashboard.tar /home/imas/opt/
 WORKDIR /home/imas/opt/
 RUN tar xf demonstrator-dashboard.tar
+COPY --chown=imas:imas external/dashboard-secrets.json /home/imas/opt/demonstrator-dashboard/dashboard/settings/secrets.json
 
 # Install requirements
 RUN python3 -m pip install -r demonstrator-dashboard/requirements.txt

--- a/external/.intentionaly_left_empty
+++ b/external/.intentionaly_left_empty
@@ -1,3 +1,0 @@
-This directory is empty for a purpose.
-
-You are supposed to put here catalog_qt_2.tar file that contains Catalog QT v.2 source codes.

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,5 @@
+This directory should contain:
+
+* `catalog_qt_2.tar` with Catalog QT v.2 source codes
+* `demonstrator-dashboard.tar` with Demonstrator Dashboard source codes
+* Filled out Keycloak configuration in `dashboard-secrets.json`

--- a/external/dashboard-secrets.json
+++ b/external/dashboard-secrets.json
@@ -1,0 +1,9 @@
+{
+    "keycloak-1":{
+        "server_url": "",
+        "realm_name": "",
+        "client_id": "",
+        "client_secret": "",
+        "remote_client_object": ""
+    }
+}

--- a/scripts/dashboard-wrapper.sh
+++ b/scripts/dashboard-wrapper.sh
@@ -20,4 +20,9 @@ while [ $loop == 1 ]; do
 
 done
 
-python3 /home/imas/opt/demonstrator-dashboard/dashboard/settings/create.py && python3 /home/imas/opt/demonstrator-dashboard/manage.py migrate && python3 /home/imas/opt/demonstrator-dashboard/manage.py runserver 0:8082 &
+python3 /home/imas/opt/demonstrator-dashboard/dashboard/settings/create.py && \
+python3 /home/imas/opt/demonstrator-dashboard/manage.py makemigrations && \
+python3 /home/imas/opt/demonstrator-dashboard/manage.py migrate && \
+python3 /home/imas/opt/demonstrator-dashboard/manage.py loaddata /home/imas/opt/demonstrator-dashboard/dashboard/fixtures/keycloak.json && \
+python3 /home/imas/opt/demonstrator-dashboard/manage.py keycloak_refresh_realm && \
+python3 /home/imas/opt/demonstrator-dashboard/manage.py runserver 0:8082 &


### PR DESCRIPTION
* Remove `.intentionaly_left_empty` and swap it with `README.md` describing what should this folder contain
* Add `external/dashboard-secrets.json`, file that should be filled out before building process

Right now, dashboard should be working out-of-the-box after cloning and archiving with `tar`.