### PR TITLE
Small changes related to changing properties files

### DIFF
--- a/docker-compose/build/Dockerfile
+++ b/docker-compose/build/Dockerfile
@@ -41,13 +41,11 @@ FROM base AS server
 
 COPY files/server.sh /server.sh
 RUN  mkdir /tmp/server
-COPY files/server/application.properties.patch /tmp/server/application.properties.patch
-COPY files/server/application.properties.overwrite /tmp/server/application.properties.overwrite
-COPY files/server/url.properties.overwrite /tmp/server/url.properties.overwrite
+COPY files/server/*properties* /tmp/server/
 
 RUN patch -p0 < /tmp/server/application.properties.patch
-RUN if [ `head -1 /tmp/server/application.properties.overwrite | grep '# Intentionally left empty' | wc -l` -eq 0 ]; then cp /tmp/server/application.properties.overwrite /catalog_qt_2/server/catalog-ws-server/src/main/resources/application.properties; fi
-RUN if [ `head -1 /tmp/server/url.properties.overwrite | grep '# Intentionally left empty' | wc -l` -eq 0 ]; then cp /tmp/server/url.properties.overwrite /catalog_qt_2/server/catalog-ws-server/src/main/resources/url.properties; fi
+RUN if [ -e /tmp/server/application.properties ]; then cp /tmp/server/application.properties /catalog_qt_2/server/catalog-ws-server/src/main/resources/application.properties; fi
+RUN if [ -e /tmp/server/url.properties ]; then cp /tmp/server/url.properties /catalog_qt_2/server/catalog-ws-server/src/main/resources/url.properties; fi
 RUN mvn --file /catalog_qt_2/server/catalog-ws-server/pom.xml package -DskipTests
 
 CMD ["/server.sh"]

--- a/docker-compose/build/files/server/application.properties.overwrite
+++ b/docker-compose/build/files/server/application.properties.overwrite
@@ -1,6 +1,0 @@
-# Intentionally left empty
-#
-#
-# If you have to prepare custom application.properties 
-# file, simply overwrite this file with the content of 
-# your application.properties file

--- a/docker-compose/build/files/server/url.properties.overwrite
+++ b/docker-compose/build/files/server/url.properties.overwrite
@@ -1,5 +1,0 @@
-# Intentionally left empty
-#
-#
-# If you have to define custom rules of endpoint authorization
-# you can drop your url.properties file here


### PR DESCRIPTION
application.properties.overwrite and url.properties.overwrite was heavily over-engineered. In fact, we don't have to keep these files inside repo. All we have to do is to add these two inside files/server/ and Dockerfile will check whether they exist or not. If files exist, they are put in place of original ones.

@tzok - if you don't have any objections, I suggest we go this way. Note that your explicit COPY of application.properties.patch is now done by COPY *properties*